### PR TITLE
fix: remove non-existent id property from TextSegment logs

### DIFF
--- a/src/lib/store/audio-queue.ts
+++ b/src/lib/store/audio-queue.ts
@@ -132,7 +132,6 @@ export const useAudioQueue = create<AudioQueueStore>()(
               })
               
               console.log('Segment converted:', {
-                segmentId: segment.id,
                 audioDataLength: audioData.length
               })
               
@@ -377,7 +376,6 @@ export const useAudioQueue = create<AudioQueueStore>()(
 
         try {
           console.log('Creating audio from stored data:', {
-            segmentId: segment.id,
             hasAudioData: !!segment.audioData,
             dataPreview: segment.audioData?.substring(0, 100) + '...'
           })
@@ -590,7 +588,6 @@ export const useAudioQueue = create<AudioQueueStore>()(
               })
               
               console.log('Segment converted:', {
-                segmentId: segment.id,
                 audioDataLength: audioData.length
               })
               


### PR DESCRIPTION
Fix TypeScript build error by removing non-existent id property from TextSegment logs

Changes made:
- Removed segmentId from console.log statements since TextSegment type doesn't have an id property
- Fixed build errors and successful compilation